### PR TITLE
Expected values are missing on assertTrue and assertFalse

### DIFF
--- a/hiro.js
+++ b/hiro.js
@@ -380,14 +380,14 @@ var hiro = (function (window, undefined) {
 			if (value)
 				return;
 
-			this.fail_({ assertion: 'assertTrue', result: value });
+			this.fail_({ assertion: 'assertTrue', expected : true, result: value });
 		},
 
 		assertFalse: function (value) {
 			if (!value)
 				return;
 
-			this.fail_({ assertion: 'assertFalse', result: value });
+			this.fail_({ assertion: 'assertFalse', expected : false, result: value });
 		},
 
 		assertEqual: function (actual, expected) {

--- a/test.js
+++ b/test.js
@@ -31,7 +31,7 @@ hiro.module('GenericTests', {
 		function exc() { throw new Error(); }
 		function noexc() { return; }
 
-		this.expect(20);
+		this.expect(22);
 		this.assertTrue(true);
 		this.assertFalse(false);
 		this.assertEqual('test', 'test');
@@ -41,6 +41,7 @@ hiro.module('GenericTests', {
 		// assertTrue
 		hiro_.once('test.onFailure', function (test, report) {
 			that.assertEqual(report.assertion, 'assertTrue');
+                        that.assertTrue(report.expected, true);
 			that.assertEqual(report.result, false);
 		});
 
@@ -51,6 +52,7 @@ hiro.module('GenericTests', {
 		// assertFalse
 		hiro_.once('test.onFailure', function (test, report) {
 			that.assertEqual(report.assertion, 'assertFalse');
+                        that.assertFalse(report.expected);
 			that.assertEqual(report.result, true);
 		});
 


### PR DESCRIPTION
Expected values are missing on assertTrue and assertFalse, which is not very handy when implementing a simple and generic handler. 
