### PR TITLE
Extra (semantic) assertions (implements #10)

### DIFF
--- a/hiro.js
+++ b/hiro.js
@@ -530,8 +530,8 @@ var hiro = (function (window, undefined) {
 			if (object instanceof prototype)
 				return;
 
-			// TODO: better expected message
-			this.fail_({ assertion: 'assertInstanceOf', expected : prototype, result: object.prototype });
+			// TODO: better expected message (http://stackoverflow.com/questions/332422/how-do-i-get-the-name-of-an-objects-type-in-javascript#answer-332429)
+			this.fail_({ assertion: 'assertInstanceOf', expected : true, result: false });
 		},
 
 		assertObjectHasProperty: function (object, property) {
@@ -542,7 +542,7 @@ var hiro = (function (window, undefined) {
 			this.fail_({ assertion: 'assertObjectHasProperty', expected : true, result: false });
 		},
 
-    // TODO: create assertIndexOf equivalent
+		// TODO: create assertIndexOf equivalent
 		assertArrayContainsValue: function (array, value) {
 			if (-1 !== array.indexOf(value))
 				return;

--- a/hiro.js
+++ b/hiro.js
@@ -470,6 +470,20 @@ var hiro = (function (window, undefined) {
 			this.fail_({ assertion: 'assertFalse', expected : false, result: value });
 		},
 
+		assertUndefined: function (value) {
+			if (undefined === value)
+				return;
+
+			this.fail_({ assertion: 'assertUndefined', expected : undefined, result: value });
+		},
+
+		assertNull: function (value) {
+			if (null === value)
+				return;
+
+			this.fail_({ assertion: 'assertNull', expected : null, result: value });
+		},
+
 		assertEqual: function (actual, expected) {
 			if (expected === actual)
 				return;
@@ -510,6 +524,31 @@ var hiro = (function (window, undefined) {
 					});
 				}
 			}
+		},
+
+		assertInstanceOf: function (object, prototype) {
+			if (object instanceof prototype)
+				return;
+
+			// TODO: better expected message
+			this.fail_({ assertion: 'assertInstanceOf', expected : prototype, result: object.prototype });
+		},
+
+		assertObjectHasProperty: function (object, property) {
+			if (property in object)
+				return;
+
+			// TODO: better expected message
+			this.fail_({ assertion: 'assertObjectHasProperty', expected : true, result: false });
+		},
+
+    // TODO: create assertIndexOf equivalent
+		assertArrayContainsValue: function (array, value) {
+			if (-1 !== array.indexOf(value))
+				return;
+
+			// TODO: better expected message
+			this.fail_({ assertion: 'assertArrayContainsValue', expected : true, result: false });
 		}
 	};
 

--- a/test.js
+++ b/test.js
@@ -38,12 +38,17 @@ hiro.module('GenericTests', {
 		function exc() { throw new Error(); }
 		function noexc() { return; }
 
-		this.expect(22);
+		this.expect(33);
 		this.assertTrue(true);
 		this.assertFalse(false);
+		this.assertUndefined(undefined);
+		this.assertNull(null);
 		this.assertEqual('test', 'test');
 		this.assertException(exc, Error);
 		this.assertNoException(noexc);
+		this.assertInstanceOf(new Error(), Error);
+		this.assertObjectHasProperty({ 'test': '' }, 'test');
+		this.assertArrayContainsValue(['test'], 'test');
 
 		// assertTrue
 		hiro_.once('test.onFailure', function (test, report) {
@@ -65,6 +70,28 @@ hiro.module('GenericTests', {
 
 		test(function () {
 			this.assertFalse(true);
+		});
+
+		// assertUndefined
+		hiro_.once('test.onFailure', function (test, report) {
+			that.assertEqual(report.assertion, 'assertUndefined');
+			that.assertUndefined(report.expected);
+			that.assertEqual(report.result, true);
+		});
+
+		test(function () {
+			this.assertUndefined(true);
+		});
+
+		// assertNull
+		hiro_.once('test.onFailure', function (test, report) {
+			that.assertEqual(report.assertion, 'assertNull');
+			that.assertNull(report.expected);
+			that.assertEqual(report.result, true);
+		});
+
+		test(function () {
+			this.assertNull(true);
 		});
 
 		// assertEqual
@@ -111,6 +138,10 @@ hiro.module('GenericTests', {
 		test(function () {
 			this.assertNoException(exc);
 		});
+
+		// TODO: add test for failing assertion with assertInstanceOf
+		// TODO: add test for failing assertion with assertObjectHasProperty
+		// TODO: add test for failing assertion with assertArrayContainsValue
 	},
 
 	/*

--- a/test.js
+++ b/test.js
@@ -38,7 +38,7 @@ hiro.module('GenericTests', {
 		function exc() { throw new Error(); }
 		function noexc() { return; }
 
-		this.expect(33);
+		this.expect(42);
 		this.assertTrue(true);
 		this.assertFalse(false);
 		this.assertUndefined(undefined);
@@ -139,9 +139,38 @@ hiro.module('GenericTests', {
 			this.assertNoException(exc);
 		});
 
-		// TODO: add test for failing assertion with assertInstanceOf
-		// TODO: add test for failing assertion with assertObjectHasProperty
-		// TODO: add test for failing assertion with assertArrayContainsValue
+		// assertInstanceOf with incorrect class
+		hiro_.once('test.onFailure', function (test, report) {
+			that.assertEqual(report.assertion, 'assertInstanceOf');
+			that.assertEqual(report.expected, true);
+			that.assertEqual(report.result, false);
+		});
+
+		test(function () {
+			this.assertInstanceOf(new Error(), Suite);
+		});
+
+		// assertObjectHasProperty with unknown property
+		hiro_.once('test.onFailure', function (test, report) {
+			that.assertEqual(report.assertion, 'assertObjectHasProperty');
+			that.assertEqual(report.expected, true);
+			that.assertEqual(report.result, false);
+		});
+
+		test(function () {
+			this.assertObjectHasProperty({}, 'test');
+		});
+
+		// assertArrayContainsValue with unknown value
+		hiro_.once('test.onFailure', function (test, report) {
+			that.assertEqual(report.assertion, 'assertArrayContainsValue');
+			that.assertEqual(report.expected, true);
+			that.assertEqual(report.result, false);
+		});
+
+		test(function () {
+			this.assertArrayContainsValue([], 'test');
+		});
 	},
 
 	/*


### PR DESCRIPTION
So far I've implemented the following assertions.
- `assertUndefined`
- `assertNull`
- `assertInstanceOf`
- `assertObjectHasProperty`
- `assertArrayContainsValue`

I'm just putting it out here so you can give early feedback. I'll try to finish this tomorrow and add a few more tests. Is there any reason why you choose to return early in the assertions? 
