### PR TITLE
Add the 'suite' attribute to Test instances

### DIFF
--- a/src/suite.js
+++ b/src/suite.js
@@ -61,7 +61,7 @@ Suite.prototype = {
 			if (name.slice(0, 4) !== "test" || !_.isFunction(func))
 				return;
 
-			var test = new Test({ name: name, func: func });
+			var test = new Test({ name: name, func: func, suite: this });
 			this.queue.push(test);
 		}, this));
 


### PR DESCRIPTION
This adds the suite attribute when instantiated the Test object. The specific purpose and usefulness of this is in events from runners, where you may want to know what suite a test is executing under without storing state from things like suite.on[Start|Complete].

i.e.

```
bind("test.onStart", function (test) {
    console.log('Running test ' + test.suite.name + '.' + test.name);
});
```
